### PR TITLE
HdPeak, add far plane culling distance setting

### DIFF
--- a/mods/HDPeak/src/HDPeak.cs
+++ b/mods/HDPeak/src/HDPeak.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Zorro.Settings;
 using SettingsExtender;
+using HarmonyLib;
 
 namespace HDPeak
 {
@@ -30,6 +31,7 @@ namespace HDPeak
     public class HDPeakPlugin : BaseUnityPlugin
     {
         internal static new ManualLogSource Logger;
+        internal static Harmony harmony;
         private GameObject buttonSrc;
         private bool settingsAdded = false;
 
@@ -40,6 +42,10 @@ namespace HDPeak
 
             // Register custom settings page
             SettingsRegistry.Register("HDPeak");
+
+            // Initialize Harmony for patching
+            harmony = new Harmony(HDPeakPluginInfo.PLUGIN_GUID);
+            harmony.PatchAll();
         }
 
         private void Start()
@@ -65,9 +71,12 @@ namespace HDPeak
                     SettingsHandler.Instance.AddSetting(new MaxLightsSetting());
                     Logger.LogInfo("Adding Dynamic Batching setting...");
                     SettingsHandler.Instance.AddSetting(new DynamicBatchingSetting());
+                    Logger.LogInfo("Adding Culling Distance setting...");
+                    SettingsHandler.Instance.AddSetting(new CullingDistanceSetting());
+
                     settingsAdded = true;
                     Logger.LogInfo("HDPeak settings added successfully!");
-                    Logger.LogInfo("Available settings: Anti-Aliasing, Anisotropic Filtering, Texture Quality, Shadow Resolution, LOD Bias, Opaque Texture, Max Additional Lights, Dynamic Batching");
+                    Logger.LogInfo("Available settings: Anti-Aliasing, Anisotropic Filtering, Texture Quality, Shadow Resolution, LOD Bias, Opaque Texture, Max Additional Lights, Dynamic Batching, Culling Distance");
                     Logger.LogInfo($"Settings added: {settingsAdded}");
                 }
                 catch (Exception ex)

--- a/mods/HDPeak/src/HDPeakSettings.cs
+++ b/mods/HDPeak/src/HDPeakSettings.cs
@@ -257,7 +257,7 @@ namespace HDPeak.Settings
     [ExtenderSetting(page: "HDPeak", displayName: "LOD Bias")]
     public class LODBiasSetting : ExtenderFloatSetting
     {
-        protected override float GetDefaultValue() => 1.0f;
+        protected override float GetDefaultValue() => 0;
         protected override float2 GetMinMaxValue() => new float2(0.5f, 2.0f);
 
         public LODBiasSetting() : base(Value => {
@@ -341,6 +341,26 @@ namespace HDPeak.Settings
                 bool enableBatching = Value == DynamicBatchingMode.Enabled;
                 urpAsset.supportsDynamicBatching = enableBatching;
             }
+        }) {}
+    }
+    
+    /// <summary>
+    /// Camera culling distance for controlling how far objects are rendered
+    /// </summary>
+    [ExtenderSetting(page: "HDPeak", displayName: "Culling Distance")]
+    public class CullingDistanceSetting : ExtenderFloatSetting
+    {
+        protected override float GetDefaultValue() => 1500;
+        protected override float2 GetMinMaxValue() => new float2(50f, 1500f);
+
+        public override void Load(ISettingsSaveLoad loader)
+        {
+            base.Load(loader);
+            HDPeak.Patches.MainCameraPatches.SetFarClipDistance((int)Value);
+        }
+
+        public CullingDistanceSetting() : base(Value => {
+            HDPeak.Patches.MainCameraPatches.SetFarClipDistance((int)Value);
         }) {}
     }
 }

--- a/mods/HDPeak/src/MainCameraPatch.cs
+++ b/mods/HDPeak/src/MainCameraPatch.cs
@@ -1,0 +1,51 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace HDPeak.Patches {
+    [HarmonyPatch]
+    public static class MainCameraPatches
+    {   
+        private static bool needsUpdate = false;
+        private static int? customFarClipPlane = null;
+
+        private static readonly AccessTools.FieldRef<MainCamera, Camera> CamRef =
+            AccessTools.FieldRefAccess<MainCamera, Camera>("cam");
+
+        [HarmonyPatch(typeof(MainCamera), "Awake")]
+        [HarmonyPostfix]
+        public static void Awake(MainCamera __instance)
+        {
+            UpdateCameraFarClipPlane(__instance);
+        }
+
+        [HarmonyPatch(typeof(MainCamera), "LateUpdate")]
+        [HarmonyPostfix]
+        public static void LateUpdate(MainCamera __instance)
+        {
+            if (needsUpdate) {
+                UpdateCameraFarClipPlane(__instance);
+            }
+        }
+
+        private static void UpdateCameraFarClipPlane(MainCamera instance)
+        {
+            var cam = CamRef(instance);
+
+            if (cam != null && customFarClipPlane.HasValue)
+            {
+                cam.farClipPlane = customFarClipPlane.Value;
+                needsUpdate = false;
+
+                HDPeak.HDPeakPlugin.Logger.LogInfo($"Camera far clip plane was updated to {customFarClipPlane.Value}");
+            }
+        }
+
+        internal static void SetFarClipDistance(int value)
+        {
+            customFarClipPlane = value;
+            needsUpdate = true;
+
+            HDPeak.HDPeakPlugin.Logger.LogInfo($"Updating culling distance");
+        }
+    }
+}


### PR DESCRIPTION
Sup. Here are the changes Ive mentioned to you regarding the culling distance setting. I've sadly ended up using a `FloatSetting` because whenever I tried using `IntSetting` on the UI the game would crash. Luckily it doesn't change much for the user except that they can see decimal numbers even though they aren't decimal

- Add a field to the plugin class for the harmony instance
- Create a custom setting class for distance and add it to the SettingsRegistry
- Use harmony to patch MainCamera class in the game for the value to be updated